### PR TITLE
Embed archive 66 resources into mod archives

### DIFF
--- a/Shared/Cdc/ResourceCollectionItemReference.cs
+++ b/Shared/Cdc/ResourceCollectionItemReference.cs
@@ -2,5 +2,11 @@
 
 namespace TrRebootTools.Shared.Cdc
 {
-    public record ResourceCollectionItemReference(ArchiveFileReference CollectionReference, int ResourceIndex);
+    /// <summary>
+    /// Reference to a resource within a resource collection.
+    /// </summary>
+    /// <param name="CollectionReference">The archive file reference for the collection (.drm file)</param>
+    /// <param name="ResourceIndex">Index of the resource within the collection</param>
+    /// <param name="ResourceArchiveId">Archive ID where the resource data is stored (for priority selection)</param>
+    public record ResourceCollectionItemReference(ArchiveFileReference CollectionReference, int ResourceIndex, int ResourceArchiveId = -1);
 }


### PR DESCRIPTION
  Fixes mod compatibility with the December 2025 Steam update for Tomb Raider (2013).

  ## Problem
  The update added `jcontent.000.tiger` (archive ID 66). When mods were installed, DRM files copied from the game
  contained resource references pointing to archive 66. This caused the game to crash with:
  > "Tiger read request doesn't belong to this archive (was 66, expected 7)"

  ## Solution
  Mods now automatically detect and embed jcontent resources directly into the mod archive, eliminating cross-archive
  references that cause crashes.

  ## Changes
  - Add `ScanCollectionsForJcontentReferences()` and `EmbedJcontentResources()` to ModInstaller.cs
  - Update ResourceUsageCache.cs to version 9 format with archiveId for priority selection
  - Add ResourceArchiveId parameter to ResourceCollectionItemReference.cs

  ## Note
  Users will need to reinstall existing mods after updating for the fix to take effect.