### PR TITLE
Retry game selection until valid game folder found or user exits

### DIFF
--- a/Extractor/Program.cs
+++ b/Extractor/Program.cs
@@ -33,8 +33,14 @@ namespace TrRebootTools.Extractor
                         break;
 
                     string? gameFolderPath = await GameFolderFinder.FindAsync(game.Value);
-                    if (gameFolderPath == null)
-                        break;
+                    while (gameFolderPath == null)
+                    {
+                        game = await GameSelectionWindow.GetGameAsync(true);
+                        if (game == null)
+                            return 0;
+
+                        gameFolderPath = await GameFolderFinder.FindAsync(game.Value);
+                    }
 
                     MainWindow window = new(gameFolderPath, game.Value);
                     await App.ShowDialogAsync(window);

--- a/HookTool/Program.cs
+++ b/HookTool/Program.cs
@@ -31,8 +31,14 @@ namespace TrRebootTools.HookTool
                     return;
 
                 string? gameFolderPath = await GameFolderFinder.FindAsync(game.Value);
-                if (gameFolderPath == null)
-                    return;
+                while (gameFolderPath == null)
+                {
+                    game = await GameSelectionWindow.GetGameAsync(true);
+                    if (game == null)
+                        return;
+
+                    gameFolderPath = await GameFolderFinder.FindAsync(game.Value);
+                }
 
                 string exePath = Path.Combine(gameFolderPath, CdcGameInfo.Get(game.Value).ExeNames[0]);
                 if (!GameProcess.SupportsHooking(exePath, game.Value, out string? unsupportedReason))

--- a/ModManager/Program.cs
+++ b/ModManager/Program.cs
@@ -39,8 +39,14 @@ namespace TrRebootTools.ModManager
                         break;
 
                     string? gameFolderPath = await GameFolderFinder.FindAsync(game.Value);
-                    if (gameFolderPath == null)
-                        break;
+                    while (gameFolderPath == null)
+                    {
+                        game = await GameSelectionWindow.GetGameAsync(true);
+                        if (game == null)
+                            return 0;
+
+                        gameFolderPath = await GameFolderFinder.FindAsync(game.Value);
+                    }
 
                     if (args.Length > 0)
                     {


### PR DESCRIPTION
Replaced the single null-check with a loop that reopens the game selection dialog until a valid folder is specified. This prevents the program from exiting early when a game folder path is missing or incorrect in `settings.json`. Previously, users could get stuck on the game folder selection window if a previously valid path became invalid (e.g., uninstalled game) or if they simply picked the wrong game, forcing them to manually edit `settings.json` to fix it.